### PR TITLE
Fix autoload issue with Capistrano 3

### DIFF
--- a/cap-newrelic.gemspec
+++ b/cap-newrelic.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'cap-newrelic'
-  spec.version       = '0.4.0'
+  spec.version       = '0.5.0'
   spec.authors       = 'Robert Coleman'
   spec.email         = 'github@robert.net.nz'
   spec.homepage      = 'http://github.com/rjocoleman/cap-newrelic'

--- a/lib/cap-newrelic.rb
+++ b/lib/cap-newrelic.rb
@@ -2,4 +2,3 @@ require 'faraday'
 require 'rexml/document'
 
 load File.expand_path('../capistrano/tasks/newrelic.rake', __FILE__)
-

--- a/lib/cap-newrelic.rb
+++ b/lib/cap-newrelic.rb
@@ -1,0 +1,5 @@
+require 'faraday'
+require 'rexml/document'
+
+load File.expand_path('../capistrano/tasks/newrelic.rake', __FILE__)
+

--- a/lib/capistrano/newrelic.rb
+++ b/lib/capistrano/newrelic.rb
@@ -1,4 +1,0 @@
-require 'faraday'
-require 'rexml/document'
-
-load File.expand_path('../tasks/newrelic.rake', __FILE__)


### PR DESCRIPTION
I had to do this fix to make cap-newrelic work with my Capistrano 3. The `cap-newrelic.rb` file was empty and the `newrelic:notify` task wasn't loaded.
